### PR TITLE
support `ignore-missing` for `glob` #284

### DIFF
--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -63,7 +63,7 @@ class Link(Plugin):
                 glob_results = self._create_glob_results(path, exclude_paths)
                 if len(glob_results) == 0:
                     self._log.warning("Globbing couldn't find anything matching " + str(path))
-                    success = False
+                    success = ignore_missing
                     continue
                 if len(glob_results) == 1 and destination[-1] == "/":
                     self._log.error("Ambiguous action requested.")


### PR DESCRIPTION
Pulling across from brutus' fork